### PR TITLE
Make `notebooks.md`'s location independent

### DIFF
--- a/notebooks.html
+++ b/notebooks.html
@@ -1,3 +1,20 @@
-<meta http-equiv="refresh" content="0; url=https://github.com/probml/pyprobml/blob/master/notebooks.md" />
+<!DOCTYPE html>
+<html>
 
+<body>
 
+    <h2>What Can JavaScript Do?</h2>
+
+    <p id="demo">JavaScript can change HTML content.</p>
+
+    <script>
+        function redirect() {
+            location.replace("https://github.com/probml/pyprobml/blob/master/notebooks.md");
+        }
+
+        window.onload = function () { redirect(); };
+
+    </script>
+</body>
+
+</html>

--- a/notebooks.html
+++ b/notebooks.html
@@ -2,16 +2,15 @@
 <html>
 
 <body>
-
-    <h2>What Can JavaScript Do?</h2>
-
-    <p id="demo">JavaScript can change HTML content.</p>
-
     <script>
         function redirect() {
-            location.replace("https://github.com/probml/pyprobml/blob/master/notebooks.md");
-        }
+            var url = location.href;
+            // split url by # and get last part
+            var notebook = url.split("#")[1];
 
+            // redirect to notebooks.md 
+            location.replace("https://github.com/probml/pyprobml/blob/master/notebooks.md#".concat(notebook));
+        }
         window.onload = function () { redirect(); };
 
     </script>

--- a/notebooks.html
+++ b/notebooks.html
@@ -9,7 +9,7 @@
             var notebook = url.split("#")[1];
 
             // redirect to notebooks.md 
-            location.replace("https://github.com/probml/pyprobml/blob/master/notebooks.md#".concat(notebook));
+            location.replace("https://github.com/probml/pyprobml/blob/auto_notebooks_md/notebooks.md".concat(notebook));
         }
         window.onload = function () { redirect(); };
 


### PR DESCRIPTION
Now we would be able to write `https://probml.github.io/notebooks#bimodal_dist_plot.ipynb` to redirect on `https://github.com/probml/pyprobml/blob/auto_notebooks_md/notebooks.md#bimodal_dist_plot.ipynb`

This is helpful because now we can change the location of `notebooks.md` anytime (after printing also) since we will write the notebook URL as `https://probml.github.io/notebooks#` in the printed book and the reader can append the notebook name with this URL irrespective of `notebooks.md`'s location. 

Thanks, Prof. @nipunbatra for sharing JS tricks :)